### PR TITLE
Add camera scrolling and item effects

### DIFF
--- a/project/editor/map_editor.py
+++ b/project/editor/map_editor.py
@@ -11,9 +11,13 @@ COLOR_LOOKUP = {
     'P': (0, 0, 255),
     'G': (255, 0, 0),
     'C': (255, 215, 0),
+    'S': (0, 255, 255),
+    'I': (255, 255, 0),
+    'F': (200, 0, 200),
+    'E': (0, 200, 0),
 }
 
-TILE_TYPES = ['.', '#', 'P', 'G', 'C']
+TILE_TYPES = ['.', '#', 'P', 'G', 'C', 'S', 'I', 'F', 'E']
 
 class MapEditor:
     """Interactive tile-based map editor."""
@@ -40,7 +44,17 @@ class MapEditor:
                         running = False
                     elif event.key == pygame.K_s:
                         save_map(self.file_path, self.map_data)
-                    elif event.key in (pygame.K_1, pygame.K_2, pygame.K_3, pygame.K_4, pygame.K_5):
+                    elif event.key in (
+                        pygame.K_1,
+                        pygame.K_2,
+                        pygame.K_3,
+                        pygame.K_4,
+                        pygame.K_5,
+                        pygame.K_6,
+                        pygame.K_7,
+                        pygame.K_8,
+                        pygame.K_9,
+                    ):
                         index = event.key - pygame.K_1
                         self.selected = TILE_TYPES[index]
                 if event.type == pygame.MOUSEBUTTONDOWN:

--- a/project/editor/map_loader.py
+++ b/project/editor/map_loader.py
@@ -2,10 +2,10 @@
 import os
 from typing import List, Tuple
 
-from game.tile import Tile
+from game.tile import Tile, GoalTile
 from game.player import Player
 from game.enemy import Enemy
-from game.item import Item
+from game.item import Item, SpeedBoostItem, InvincibilityItem, ProjectileItem
 
 TILE_SIZE = 32
 
@@ -38,6 +38,15 @@ def load_map(file_path: str) -> Tuple[List[List[str]], Player, list, list, list]
                 enemies.append(Enemy(world_x, world_y))
             elif char == 'C':
                 items.append(Item(world_x, world_y, 'coin'))
+            elif char == 'S':
+                items.append(SpeedBoostItem(world_x, world_y))
+            elif char == 'I':
+                items.append(InvincibilityItem(world_x, world_y))
+            elif char == 'F':
+                items.append(ProjectileItem(world_x, world_y))
+            elif char == 'E':
+                tiles.append(GoalTile(world_x, world_y))
+    player.spawn = player.rect.topleft
     return lines, player, tiles, enemies, items
 
 

--- a/project/game/enemy.py
+++ b/project/game/enemy.py
@@ -7,10 +7,11 @@ MOVE_SPEED = -2
 class Enemy(GameObject):
     """Simple enemy that walks left and right."""
 
-    def __init__(self, x, y):
+    def __init__(self, x, y, point_value=100):
         super().__init__(x, y, TILE_SIZE, TILE_SIZE, color=(255, 0, 0))
         self.vel_x = MOVE_SPEED
         self.vel_y = 0
+        self.point_value = point_value
 
     def apply_gravity(self):
         self.vel_y += 0.5

--- a/project/game/game.py
+++ b/project/game/game.py
@@ -3,6 +3,7 @@ import pygame
 
 from editor.map_loader import load_map
 from editor.map_editor import MapEditor
+from game.projectile import Projectile
 
 TILE_SIZE = 32
 SCREEN_WIDTH = 640
@@ -21,14 +22,18 @@ class Game:
         # Load level
         self.load_world()
         self.running = True
+        self.camera_x = 0
+        self.projectiles = []
 
     def load_world(self):
         """Load game objects from map file."""
         data = load_map(self.map_file)
         self.map_data, self.player, self.tiles, self.enemies, self.items = data
+        self.map_width = len(self.map_data[0]) * TILE_SIZE if self.map_data else SCREEN_WIDTH
 
     def run(self):
         """Main loop for the game."""
+        self.player.start_time = pygame.time.get_ticks()
         while self.running:
             self.clock.tick(60)
             for event in pygame.event.get():
@@ -39,26 +44,77 @@ class Game:
                     self.map_data = editor.run()
                     self.load_world()
             # Update objects
-            self.player.update(self.tiles, self.enemies, self.items)
+            self.player.update(self.tiles, self.enemies, self.items, self.projectiles)
             for enemy in self.enemies:
                 enemy.update(self.tiles)
+            for projectile in self.projectiles[:]:
+                projectile.update()
+                remove = False
+                for tile in self.tiles:
+                    if tile.tile_type == '#':
+                        if projectile.rect.colliderect(tile.rect):
+                            remove = True
+                            break
+                if remove:
+                    self.projectiles.remove(projectile)
+                    continue
+                for enemy in self.enemies[:]:
+                    if projectile.rect.colliderect(enemy.rect):
+                        self.enemies.remove(enemy)
+                        self.projectiles.remove(projectile)
+                        self.player.enemies_killed += 1
+                        break
+
+            # Update camera position
+            self.camera_x = max(
+                0,
+                min(
+                    self.player.rect.centerx - SCREEN_WIDTH // 2,
+                    self.map_width - SCREEN_WIDTH,
+                ),
+            )
+
+            # Goal check
+            for tile in self.tiles:
+                if tile.tile_type == 'E' and self.player.rect.colliderect(tile.rect):
+                    self.player.end_time = pygame.time.get_ticks()
+                    self.running = False
+                    break
             # Draw
             self.draw()
             pygame.display.flip()
+        self.show_final_score()
         pygame.quit()
 
     def draw(self):
         self.screen.fill((135, 206, 235))
         for tile in self.tiles:
-            tile.draw(self.screen)
+            tile.draw(self.screen, self.camera_x)
         for item in self.items:
-            item.draw(self.screen)
+            item.draw(self.screen, self.camera_x)
         for enemy in self.enemies:
-            enemy.draw(self.screen)
-        self.player.draw(self.screen)
+            enemy.draw(self.screen, self.camera_x)
+        for projectile in self.projectiles:
+            projectile.draw(self.screen, self.camera_x)
+        self.player.draw(self.screen, self.camera_x)
         self.draw_ui()
 
     def draw_ui(self):
         font = pygame.font.SysFont(None, 24)
         text = font.render(f"Score: {self.player.score}", True, (0, 0, 0))
         self.screen.blit(text, (10, 10))
+        status_y = 30
+        if pygame.time.get_ticks() < self.player.invincible_until:
+            inv = font.render("INVINCIBLE", True, (255, 0, 0))
+            self.screen.blit(inv, (10, status_y))
+            status_y += 20
+        if self.player.can_shoot:
+            shoot = font.render("CAN SHOOT", True, (0, 0, 0))
+            self.screen.blit(shoot, (10, status_y))
+
+    def show_final_score(self):
+        time_taken = (self.player.end_time - self.player.start_time) / 1000
+        enemies_score = self.player.enemies_killed * 100
+        final_score = enemies_score - (self.player.deaths * 100) - (time_taken * 2)
+        print(f"Final Score: {int(final_score)}")
+

--- a/project/game/game_object.py
+++ b/project/game/game_object.py
@@ -8,12 +8,13 @@ class GameObject:
         self.image = None
         self.color = color
 
-    def draw(self, screen):
-        """Draw the object to the screen."""
+    def draw(self, screen, camera_x=0):
+        """Draw the object to the screen taking camera offset into account."""
+        draw_rect = self.rect.move(-camera_x, 0)
         if self.image:
-            screen.blit(self.image, self.rect)
+            screen.blit(self.image, draw_rect)
         else:
-            pygame.draw.rect(screen, self.color, self.rect)
+            pygame.draw.rect(screen, self.color, draw_rect)
 
     def update(self, tiles):
         """Update the object. To be overridden by subclasses."""

--- a/project/game/item.py
+++ b/project/game/item.py
@@ -4,9 +4,31 @@ from .game_object import GameObject
 TILE_SIZE = 32
 
 class Item(GameObject):
-    """Collectible item."""
+    """Base collectible item."""
 
-    def __init__(self, x, y, item_type):
-        color = (255, 215, 0) if item_type == 'coin' else (0, 255, 0)
+    def __init__(self, x, y, item_type, color=None):
+        if color is None:
+            color = (255, 215, 0) if item_type == "coin" else (0, 255, 0)
         super().__init__(x, y, TILE_SIZE, TILE_SIZE, color=color)
         self.item_type = item_type
+
+
+class SpeedBoostItem(Item):
+    """Permanently increases player's speed."""
+
+    def __init__(self, x, y):
+        super().__init__(x, y, "speed", color=(0, 255, 255))
+
+
+class InvincibilityItem(Item):
+    """Grants temporary invincibility."""
+
+    def __init__(self, x, y):
+        super().__init__(x, y, "invincibility", color=(255, 255, 0))
+
+
+class ProjectileItem(Item):
+    """Allows the player to shoot projectiles."""
+
+    def __init__(self, x, y):
+        super().__init__(x, y, "projectile", color=(200, 0, 200))

--- a/project/game/player.py
+++ b/project/game/player.py
@@ -1,5 +1,6 @@
 import pygame
 from .game_object import GameObject
+from .projectile import Projectile
 
 # Physics constants
 GRAVITY = 0.5
@@ -12,22 +13,44 @@ class Player(GameObject):
 
     def __init__(self, x, y):
         super().__init__(x, y, TILE_SIZE, TILE_SIZE, color=(0, 0, 255))
+        self.spawn = (x, y)
         self.vel_x = 0
         self.vel_y = 0
         self.on_ground = False
         self.score = 0
+        self.move_speed = MOVE_SPEED
+        self.invincible_until = 0
+        self.can_shoot = False
+        self.last_shot = 0
+        self.deaths = 0
+        self.enemies_killed = 0
+        self.start_time = 0
+        self.end_time = 0
+        self.direction = 1
 
     def handle_input(self):
         """Process keyboard input for movement."""
         keys = pygame.key.get_pressed()
         self.vel_x = 0
         if keys[pygame.K_LEFT]:
-            self.vel_x = -MOVE_SPEED
+            self.vel_x = -self.move_speed
+            self.direction = -1
         if keys[pygame.K_RIGHT]:
-            self.vel_x = MOVE_SPEED
+            self.vel_x = self.move_speed
+            self.direction = 1
         if keys[pygame.K_UP] and self.on_ground:
             self.vel_y = JUMP_POWER
             self.on_ground = False
+
+    def shoot(self, projectiles):
+        if self.can_shoot:
+            keys = pygame.key.get_pressed()
+            if keys[pygame.K_SPACE]:
+                current_time = pygame.time.get_ticks()
+                if current_time - self.last_shot > 300:
+                    proj = Projectile(self.rect.centerx, self.rect.centery, self.direction)
+                    projectiles.append(proj)
+                    self.last_shot = current_time
 
     def apply_gravity(self):
         """Apply gravity to the player."""
@@ -55,10 +78,11 @@ class Player(GameObject):
                         self.rect.top = tile.rect.bottom
                         self.vel_y = 0
 
-    def update(self, tiles, enemies, items):
+    def update(self, tiles, enemies, items, projectiles):
         """Update the player position and handle interactions."""
         self.handle_input()
         self.apply_gravity()
+        self.shoot(projectiles)
         # Horizontal movement
         self.rect.x += self.vel_x
         self.horizontal_collisions(tiles)
@@ -66,18 +90,29 @@ class Player(GameObject):
         self.rect.y += self.vel_y
         self.vertical_collisions(tiles)
         # Item collection
+        current_time = pygame.time.get_ticks()
         for item in items[:]:
             if self.rect.colliderect(item.rect):
                 if item.item_type == 'coin':
                     self.score += 1
+                elif item.item_type == 'speed':
+                    self.move_speed += 2
+                elif item.item_type == 'invincibility':
+                    self.invincible_until = current_time + 5000
+                elif item.item_type == 'projectile':
+                    self.can_shoot = True
                 items.remove(item)
         # Enemy interaction
         for enemy in enemies[:]:
             if self.rect.colliderect(enemy.rect):
                 if self.vel_y > 0 and self.rect.bottom - enemy.rect.top < 20:
                     enemies.remove(enemy)
+                    self.enemies_killed += 1
                     self.vel_y = JUMP_POWER / 2
                 else:
-                    # Simple death -> reset score and position
-                    self.rect.topleft = (0, 0)
-                    self.score = 0
+                    if current_time > self.invincible_until:
+                        self.rect.topleft = self.spawn
+                        self.vel_x = self.vel_y = 0
+                        self.deaths += 1
+                    else:
+                        enemies.remove(enemy)

--- a/project/game/projectile.py
+++ b/project/game/projectile.py
@@ -1,0 +1,16 @@
+import pygame
+from .game_object import GameObject
+
+TILE_SIZE = 32
+
+class Projectile(GameObject):
+    """Simple horizontal projectile."""
+
+    def __init__(self, x, y, direction):
+        super().__init__(x, y, 10, 4, color=(50, 50, 50))
+        self.direction = direction
+        self.speed = 8
+
+    def update(self):
+        self.rect.x += self.speed * self.direction
+

--- a/project/game/tile.py
+++ b/project/game/tile.py
@@ -6,6 +6,7 @@ TILE_SIZE = 32
 COLOR_MAP = {
     '#': (100, 100, 100),
     '.': (0, 0, 0),
+    'E': (0, 200, 0),
 }
 
 class Tile(GameObject):
@@ -15,3 +16,10 @@ class Tile(GameObject):
         color = COLOR_MAP.get(tile_type, (100, 100, 100))
         super().__init__(x, y, TILE_SIZE, TILE_SIZE, color=color)
         self.tile_type = tile_type
+
+
+class GoalTile(Tile):
+    """Special tile marking the level goal."""
+
+    def __init__(self, x, y):
+        super().__init__(x, y, 'E')


### PR DESCRIPTION
## Summary
- implement scrolling camera and map boundary limits
- create new item types, projectiles, and goal tiles
- extend player with effects, shooting, and death counters
- update map loader and editor for new symbols
- display player status HUD and compute final score

## Testing
- `python3 -m py_compile project/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686bcc92319083319a7985ecd5004c5f